### PR TITLE
Add automation workflow for scheduled notebook execution

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt || echo "no requirements.txt found"
-          pip install jupyter nbconvert pandas
+          pip install jupyter nbconvert pandas requests feedparser beautifulsoup4 python-dateutil urllib3
 
       # 4️⃣ Execute the notebook and generate output file
       - name: Execute CounterPartyData.ipynb

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,0 +1,49 @@
+name: Auto Update Counterparty Data
+
+on:
+  schedule:
+    # Run every 10 minutes (uses UTC time)
+    - cron: "*/10 * * * *"
+  workflow_dispatch:  # Allow manual trigger from the Actions tab
+
+jobs:
+  run-notebook:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1️⃣ Check out repository code into the runner
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2️⃣ Set up Python environment
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      # 3️⃣ Install dependencies
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt || echo "no requirements.txt found"
+          pip install jupyter nbconvert pandas
+
+      # 4️⃣ Execute the notebook and generate output file
+      - name: Execute CounterPartyData.ipynb
+        run: |
+          jupyter nbconvert --to notebook --execute CounterPartyData.ipynb --output CounterPartyData_output.ipynb
+
+      # 5️⃣ Upload executed notebook as an artifact for later download
+      - name: Upload executed notebook
+        uses: actions/upload-artifact@v4
+        with:
+          name: executed-notebook
+          path: CounterPartyData_output.ipynb
+
+      # 6️⃣ Commit and push the updated CSV file back to the repository
+      - name: Commit and push updated CSV
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "actions@github.com"
+          git add data/jpm_press_releases.csv
+          git commit -m "Auto update CSV [skip ci]" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
This PR adds a GitHub Actions workflow (`update-data.yml`) that automates the execution of the `CounterPartyData.ipynb` notebook.

### Key updates
- Added `.github/workflows/update-data.yml`
- Workflow runs every 10 minutes (UTC) and can also be triggered manually
- Installs dependencies (`feedparser`, `requests`, `beautifulsoup4`, `python-dateutil`, etc.)
- Executes the notebook and uploads the executed version as an artifact
- Commits updated CSV outputs automatically to the repository

### Current status
The workflow pipeline itself is functioning correctly — it sets up the environment, installs dependencies, and triggers the notebook execution as expected.  
However, the notebook currently encounters an internal code error (`ValueError: not enough values to unpack`), which needs to be fixed in the notebook logic.  
Once the notebook code is corrected, the entire automation flow will run successfully end-to-end.

### Purpose
This automation enables continuous data ingestion and keeps the `jpm_press_releases.csv` file up to date without manual intervention.  
It will ensure that future data updates and notebook executions occur seamlessly through GitHub Actions.
